### PR TITLE
Adjust tests to conform with Jackson style

### DIFF
--- a/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
+++ b/src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java
@@ -754,11 +754,6 @@ public class FilteringParserDelegate extends JsonParserDelegate
                     if (returnEnd) {
                         return t;
                     }
-                    if (gotEnd /*|| (_headContext == buffRoot)
-                    this makes BasicParserFilteringTest.testNotAllowMultipleMatchesWithPath4 fail
-                    */) {
-                        return null;
-                    }
                 }
                 continue main_loop;
             case ID_END_OBJECT:
@@ -786,9 +781,7 @@ public class FilteringParserDelegate extends JsonParserDelegate
                 if (returnEnd) {
                     return t;
                 }
-                if (gotEnd /*|| (_headContext == buffRoot)
-                    this makes BasicParserFilteringTest.testNotAllowMultipleMatchesWithPath4 fail
-                */) {
+                if (gotEnd) {
                     return null;
                 }
             }


### PR DESCRIPTION
Adds 1 new test to BasicParserFilteringTest, and switches the implementation of all testExcludeObject* methods to build on existing Jackson testing infrastructure.